### PR TITLE
Implements `std::fmt::Display` for `CanId`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "can-socket"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "assert2",
  "can-socket",

--- a/can-socket/CHANGELOG
+++ b/can-socket/CHANGELOG
@@ -1,3 +1,6 @@
+# Unreleased
+- [add][minor] Implement `Display` for `CanId`, `StandardId` and `ExtendedId`.
+
 # Version 0.3.4 - 2025-07-31
 - [add][minor] Implement `Hash` for `CanId`, `StandardId` and `ExtendedId`.
 

--- a/can-socket/Cargo.toml
+++ b/can-socket/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "can-socket"
 description = "no frills CAN sockets (synchronous or async with tokio)"
-version = "0.3.4"
+version = "0.3.5"
 license = "BSD-2-Clause"
 keywords = ["CAN", "SocketCAN", "socket", "CANbus", "network"]
 categories = ["os", "hardware-support", "network-programming", "science::robotics"]

--- a/can-socket/src/id.rs
+++ b/can-socket/src/id.rs
@@ -343,15 +343,6 @@ impl ExtendedId {
 	}
 }
 
-impl std::fmt::Display for CanId {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			CanId::Standard(x) => write!(f, "0x{:03X}", x.id),
-			CanId::Extended(x) => write!(f, "0x{:08X}", x.id),
-		}
-	}
-}
-
 impl PartialEq<StandardId> for CanId {
 	fn eq(&self, other: &StandardId) -> bool {
 		self.as_standard().is_some_and(|x| x == *other)
@@ -536,6 +527,27 @@ fn parse_number(input: &str) -> Result<u32, std::num::ParseIntError> {
 		u32::from_str_radix(binary, 2)
 	} else {
 		input.parse()
+	}
+}
+
+impl std::fmt::Display for CanId {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			CanId::Standard(x) => x.fmt(f),
+			CanId::Extended(x) => x.fmt(f),
+		}
+	}
+}
+
+impl std::fmt::Display for StandardId {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "0x{:03X}", self.id)
+	}
+}
+
+impl std::fmt::Display for ExtendedId {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "0x{:08X}", self.id)
 	}
 }
 

--- a/can-socket/src/id.rs
+++ b/can-socket/src/id.rs
@@ -346,8 +346,8 @@ impl ExtendedId {
 impl std::fmt::Display for CanId {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			CanId::Standard(x) => write!(f, "{}", x.id),
-			CanId::Extended(x) => write!(f, "{}", x.id),
+			CanId::Standard(x) => write!(f, "0x{:03X}", x.id),
+			CanId::Extended(x) => write!(f, "0x{:08X}", x.id),
 		}
 	}
 }

--- a/can-socket/src/id.rs
+++ b/can-socket/src/id.rs
@@ -343,6 +343,15 @@ impl ExtendedId {
 	}
 }
 
+impl std::fmt::Display for CanId {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			CanId::Standard(x) => write!(f, "{}", x.id),
+			CanId::Extended(x) => write!(f, "{}", x.id),
+		}
+	}
+}
+
 impl PartialEq<StandardId> for CanId {
 	fn eq(&self, other: &StandardId) -> bool {
 		self.as_standard().is_some_and(|x| x == *other)
@@ -557,13 +566,13 @@ impl std::fmt::Debug for ExtendedId {
 
 impl std::fmt::LowerHex for StandardId {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		self.as_u16().fmt(f)
+		std::fmt::LowerHex::fmt(&self.as_u16(), f)
 	}
 }
 
 impl std::fmt::LowerHex for ExtendedId {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		self.as_u32().fmt(f)
+		std::fmt::LowerHex::fmt(&self.as_u32(), f)
 	}
 }
 
@@ -578,13 +587,13 @@ impl std::fmt::LowerHex for CanId {
 
 impl std::fmt::UpperHex for StandardId {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		self.as_u16().fmt(f)
+		std::fmt::UpperHex::fmt(&self.as_u16(), f)
 	}
 }
 
 impl std::fmt::UpperHex for ExtendedId {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		self.as_u32().fmt(f)
+		std::fmt::UpperHex::fmt(&self.as_u32(), f)
 	}
 }
 

--- a/can-socket/tests/compile-fail/extended_id_too_high.stderr
+++ b/can-socket/tests/compile-fail/extended_id_too_high.stderr
@@ -1,8 +1,8 @@
-error[E0080]: evaluation of `main::{constant#0}` failed
+error[E0080]: evaluation panicked: invalid extended CAN ID
  --> tests/compile-fail/extended_id_too_high.rs:2:12
   |
 2 |     let _id = can_socket::extended_id!(0x2000_0000);
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: invalid extended CAN ID
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#0}` failed here
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `can_socket::extended_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/can-socket/tests/compile-fail/id_too_high1.stderr
+++ b/can-socket/tests/compile-fail/id_too_high1.stderr
@@ -1,8 +1,8 @@
-error[E0080]: evaluation of `main::{constant#0}` failed
+error[E0080]: evaluation panicked: invalid CAN ID
  --> tests/compile-fail/id_too_high1.rs:2:12
   |
 2 |     let _id = can_socket::can_id!(0x2000_0000);
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: invalid CAN ID
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#0}` failed here
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `can_socket::can_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/can-socket/tests/compile-fail/id_too_high2.stderr
+++ b/can-socket/tests/compile-fail/id_too_high2.stderr
@@ -1,8 +1,8 @@
-error[E0080]: evaluation of `main::{constant#0}` failed
+error[E0080]: evaluation panicked: invalid standard CAN ID
  --> tests/compile-fail/id_too_high2.rs:2:12
   |
 2 |     let _id = can_socket::can_id!(standard: 0x800);
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: invalid standard CAN ID
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#0}` failed here
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `can_socket::can_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/can-socket/tests/compile-fail/id_too_high3.stderr
+++ b/can-socket/tests/compile-fail/id_too_high3.stderr
@@ -1,8 +1,8 @@
-error[E0080]: evaluation of `main::{constant#0}` failed
+error[E0080]: evaluation panicked: invalid extended CAN ID
  --> tests/compile-fail/id_too_high3.rs:2:12
   |
 2 |     let _id = can_socket::can_id!(extended: 0x2000_0000);
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: invalid extended CAN ID
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#0}` failed here
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `can_socket::can_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/can-socket/tests/compile-fail/standard_id_too_high.stderr
+++ b/can-socket/tests/compile-fail/standard_id_too_high.stderr
@@ -1,8 +1,8 @@
-error[E0080]: evaluation of `main::{constant#0}` failed
+error[E0080]: evaluation panicked: invalid standard CAN ID
  --> tests/compile-fail/standard_id_too_high.rs:2:12
   |
 2 |     let _id = can_socket::standard_id!(0x800);
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: invalid standard CAN ID
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::{constant#0}` failed here
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `can_socket::standard_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
Implements the Display trait for CanId. CanIds are rendered as decimal numbers, dropping the information whether they are extended or standard.

A little disambiguation change has been necessary for Lower and UpperHex.

Of course what Display should implement is highly subjective and this would be just what is handy in my use case. So no worries if you don't like this way of "Display", I would find another way around, but this would be the most elegant (as far as I am aware the orphaning rule forbids implementation of Traits for foreign crates).